### PR TITLE
Add Bootstrap to registration form

### DIFF
--- a/accounts/templates/accounts/register.html
+++ b/accounts/templates/accounts/register.html
@@ -1,24 +1,29 @@
-<h1>Register</h1>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}Profiles{% endblock %}</title>
+    
+    <!-- Use to CDN deliver cached version of Bootstrap’s compiled CSS and JS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+</head>
 
-{% if messages %}
-<ul class="messages">
-    {% for message in messages %}
-    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
+<body>
+    <div class="container-lg my-5">
+        <h1>Create Account</h1>
 
-<form method='POST'>
-    {% csrf_token %}
+        {% include "../messages.html" %}
 
-    <table>
-        {{ userCreationForm.as_table }}
-        {{ profileCreationForm.as_table }}
-
-        <tr>
-            <td>
-                <input type="submit" name="submit" value="Register" />
-            </td>
-        </tr>
-    </table>
-</form>
+        <div class="form-group">
+            <form method='POST'>
+                {% csrf_token %}
+                <table>
+                    {{ userCreationForm.as_table }}
+                    {{ profileCreationForm.as_table }}
+                </table>
+                <button type="submit" class="btn btn-primary">Submit</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -25,9 +25,15 @@ def register(request):
             profile.user = user # create the profile's foreign key to user and save
             profile.save()
             
-            messages.success(request, 'User and profile created successfully') # flash a success message
+            messages.success(request, 'Account created successfully') # flash a success message
             return HttpResponse('Created user and profile!')
         else:
+            for error in profileCreationForm.errors:
+                messages.error(request, profileCreationForm.errors[error])
+                return redirect(request.path)
+            for error in userCreationForm.errors:
+                messages.error(request, userCreationForm.errors[error])
+                return redirect(request.path)
             return HttpResponse('Failed to create user and profile :(')
   
     # if this URL was requested via a GET method, display a form to register a user

--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -1,13 +1,14 @@
-from django.forms import ModelForm
 from django import forms
 from .models import Profile
 
-class ProfileCreationForm(ModelForm):
+class ProfileCreationForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = ['dob', 'faith_tradition', 'phone']
         
         # override the default textfield type of dob to be a datepicker instead
         widgets = {
-            'dob' : forms.DateInput(attrs={'type': 'date'})
+            'dob' : forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
+            'faith_tradition': forms.Select(attrs={'class': 'form-control'}),
+            'phone': forms.TextInput(attrs={'class': 'form-control'}),
         }

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -19,7 +19,7 @@ class Profile(models.Model):
 
     # Each `Profile` may have a date of birth so that the commentaries they see
     # can be tailored to their age group.
-    dob = models.DateField(validators=[validate_dob], null=True, blank=True)
+    dob = models.DateField(validators=[validate_dob], null=True, blank=True, verbose_name="Birthdate")
 
     class FaithTradition(models.TextChoices):
         '''
@@ -33,11 +33,11 @@ class Profile(models.Model):
     # Each `Profile` keeps track of the faith tradition of the user. This will
     # be used so that users can filter the comments they see based on the 
     # faith tradition of the authors of the comments.
-    faith_tradition = models.CharField(choices=FaithTradition.choices, max_length=10)
+    faith_tradition = models.CharField(choices=FaithTradition.choices, max_length=10, verbose_name="Faith Tradition")
 
     # Each `Profile` contains an optional phone number field that is validated
     # against a regex.
-    phone = models.CharField(validators=[validate_phone], max_length=60, null=True, blank=True)
+    phone = models.CharField(validators=[validate_phone], max_length=60, null=True, blank=True, verbose_name="Phone Number")
     
     def __str__(self):
         '''

--- a/theologos/settings.py
+++ b/theologos/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -38,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     
+    'theologos',
     'accounts',
     'profiles',
     'commentary',

--- a/theologos/templates/messages.html
+++ b/theologos/templates/messages.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}Messages{% endblock %}</title>
+    
+    <!-- Use to CDN deliver cached version of Bootstrap’s compiled CSS and JS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+</head>
+
+<!-- Display notifications using Django messages framework -->
+{% if messages %}
+<ul class="messages">
+    {% for message in messages %}
+    <div class="alert {{message.tags}} alert-warning alert-dismissible show" role="alert" >
+        <span>{{ message }}</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}
+</ul>
+{% endif %}
+
+</html>


### PR DESCRIPTION
**Linked issues:** Resolves #32 

**Changes:** Added Bootstrap styling to `accounts/templates/accounts/register.html`, which contains the combined `User` and `Profile` form and tested that the form still works. Other changes are to improve the form, such as adding verbose names to the `Profile` model and adding error messages in the `accounts/views.py`. I also moved the Django messages logic from `register.html` to `theologos/templates/messages.html` so that it is reusable.

Demo picture is here: https://github.com/HSamiul/theologos/commit/9ea0f10eef0ea17a45db40530d2e47b8da84bc21#commitcomment-105291952