### PR TITLE
Implemented Bible reading view and navigation

### DIFF
--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -72,4 +72,11 @@
         </div>
     </div>
 </div>
+<script>
+    // Scroll to selected verse (to counteract reloading the page to the top)
+    var bookSymbol = "{{ book.symbol }}";
+    var chapterNum = "{{ chapter.number }}";
+    var verseNum = "{{ verse.number }}"
+    document.getElementById('verse-' + bookSymbol + '-' + chapterNum + '-' + verseNum).scrollIntoView({behavior: 'smooth'});
+</script>
 {% endblock %}

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -9,15 +9,22 @@
     <div class="row" style="overflow-y: hidden">
         <div class="col me-5" style="height: 90vh; overflow-y: scroll;"> <!-- left half of page is the bible -->
 
-            <p class="my-4">
-            {% for verse in verses %}
-            <!-- TODO: Move inline style to dedicated CSS file; add hover effect. -->
-            <a href="{% url "index" book_symbol=book.symbol chapter_num=chapter.number verse_num=verse.number %}"
-               style="text-decoration: none; color: inherit;">
-                <sup>{{ verse.number }}</sup> {{ verse.original_text }}
-            </a>
+            {% for book in books %}
+            <h1 style="padding-top: 50px;">{{ book.full_title }}</h1>
+                {% for chapter in book.chapter_set.all %}
+                    <h2>{{ chapter.number }}</h2>
+                    <p>
+                    {% for verse in chapter.verse_set.all %}
+                        <!-- Jump to the desired verse with a similar url to /bible/#phil-1-1 -->
+                        <a href="{% url "index" book_symbol=book.symbol chapter_num=chapter.number verse_num=verse.number %}"
+                            id="verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}"
+                            style="text-decoration: none; color: inherit; scroll-margin: 30px;">
+                            <sup>{{ verse.number }}</sup> {{ verse.original_text }}
+                        </a>
+                    {% endfor %}
+                    </p>
+                {% endfor %}
             {% endfor %}
-            </p>
         </div>
 
         <div class="col ms-5" style="height: 90vh; overflow-y: scroll;"> <!-- right half of page is commentary -->

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -6,9 +6,8 @@
 
 {% block content %}
 <div class="container my-5">
-    <div class="row">
-        <div class="col me-5"> <!-- left half of page is the bible -->
-            <h2>{{ book.full_title }} {{ chapter.number }}</h2>
+    <div class="row" style="overflow-y: hidden">
+        <div class="col me-5" style="height: 90vh; overflow-y: scroll;"> <!-- left half of page is the bible -->
 
             <p class="my-4">
             {% for verse in verses %}
@@ -21,9 +20,8 @@
             </p>
         </div>
 
-        <div class="col ms-5"> <!-- right half of page is commentary -->
-        <h2>Commentary</h2>
-
+        <div class="col ms-5" style="height: 90vh; overflow-y: scroll;"> <!-- right half of page is commentary -->
+        <h2 style="padding-top: 50px;">Commentary</h2>
             {% if verse %} <!-- if the URL specifies a selected verse number, show commentary -->
             <h5 class="my-4">{{ verse.original_text }}</h5>
 

--- a/bible/urls.py
+++ b/bible/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    # e.g. /bible/gen/1/
-    path('<slug:book_symbol>/<int:chapter_num>/', views.index, name='index'), # serves as URL for many possible pages
+    path('', views.index, name='index'),
+    # e.g. /bible/phil/1/1/
     path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/', views.index, name='index')
 ]

--- a/bible/views.py
+++ b/bible/views.py
@@ -4,21 +4,20 @@ from django.http import HttpResponse, HttpResponseRedirect
 from .models import Book, Chapter, Verse
 from commentary.forms import PostCreationForm
 
-def index(request, book_symbol, chapter_num, verse_num=None): # TODO add version_id in the future
-    book = get_object_or_404(Book, pk=book_symbol)
-    chapter = get_object_or_404(Chapter, book=book, number=chapter_num)
-    verses = chapter.verse_set.order_by("id")
-    
-    if not verse_num: # the user is just viewing the chapter
+def index(request, book_symbol=None, chapter_num=None, verse_num=None): # TODO add version_id in the future
+    books = Book.objects.all()
+
+    if not book_symbol and not chapter_num and not verse_num: # the user is reading the Bible from the top
         context = {
-            'book' : book, 
-            'chapter' : chapter,
-            'verses': verses
+            'books' : books,
             }
         
         return render(request, 'bible/index.html', context)
-        
+    
     else: # the user is viewing OR submitting commentary for a specific verse
+        book = get_object_or_404(Book, pk=book_symbol)
+        chapter = get_object_or_404(Chapter, book=book, number=chapter_num)
+        verses = chapter.verse_set.order_by("id")
         verse = get_object_or_404(Verse, chapter=chapter, number=verse_num)
         posts = verse.post_set.order_by('creation_time')
         
@@ -26,6 +25,7 @@ def index(request, book_symbol, chapter_num, verse_num=None): # TODO add version
             postCreationForm = PostCreationForm()
         
             context = {
+                'books' : books,
                 'book' : book,
                 'chapter' : chapter,
                 'verses': verses,

--- a/templates/partials/nav_bar.html
+++ b/templates/partials/nav_bar.html
@@ -1,6 +1,6 @@
 <!-- TODO: make the left and right margins larger -->
 <!-- TODO: figure out why the navbar doesn't collapse into a hamburger menu when screen gets small -->
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
     <a class="navbar-brand" href={% url 'home' %}>Theologos</a>
 
     <div class="collapse navbar-collapse">

--- a/templates/partials/nav_bar.html
+++ b/templates/partials/nav_bar.html
@@ -4,9 +4,66 @@
     <a class="navbar-brand" href={% url 'home' %}>Theologos</a>
 
     <div class="collapse navbar-collapse">
+
+        <!-- Bible navigation menu -->
+        {% if "bible" in request.path %}
+
+        <div class="navbar-nav"> <!-- me-auto pushes account items to the right -->
+            <a class="nav-item nav-link" href={% url 'home' %}>Home</a>
+        </div>
+
+        <div class="dropdown me-auto">
+            <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="outside" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Bible
+            </a>
+            <ul class="dropdown-menu">
+                {% for book in books %}
+                    <li class="dropend">
+                        <a class="dropdown-item dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown">{{ book.full_title }}</a>
+                        <ul class="dropdown-menu">
+                            {% for chapter in book.chapter_set.all %}
+                            <li>
+                                <a class="dropdown-item dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown" href="#">{{ book.full_title }} {{ chapter.number }}</a>
+                                <ul class="dropdown-menu">
+                                    {% for verse in chapter.verse_set.all %}
+                                        <li>
+                                            <a class="dropdown-item"
+                                                id="nav-{{book.symbol}}-{{chapter.number}}-{{verse.number}}"
+                                                onclick="console.log(this.id)">
+                                                {{ book.full_title }} {{ chapter.number }}:{{ verse.number }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+        <script>
+            // Make verses in Bible navigation clickable
+            {% for book in books %}
+                {% for chapter in book.chapter_set.all %}
+                    {% for verse in chapter.verse_set.all %}
+                        document.getElementById("nav-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").addEventListener('click', function(e) {
+                            e.preventDefault();
+                            document.getElementById("verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").scrollIntoView({behavior: 'smooth'});
+                            document.getElementById("verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").click();
+                        });
+                    {% endfor %}
+                {% endfor %}
+            {% endfor %}
+        </script>
+
+        {% else %}
+
         <div class="navbar-nav me-auto"> <!-- me-auto pushes account items to the right -->
             <a class="nav-item nav-link" href={% url 'home' %}>Home</a>
         </div>
+
+        {% endif %}
 
         <div class="navbar-nav">
             {% if user.is_authenticated %}


### PR DESCRIPTION
**Linked Issues:** Resolves #56 and #57.

**Changes:**
- Improved user interaction of Bible and Commentary split view by fixing the navbar to the top of the page even while scrolling (`templates/partials/nav_bar.html`) and by allowing overflow scrolling for the Bible and Commentary split views (`bible/templates/bible/index.html`)
- Added entire Bible to the context returned by index view (`bible/views.py`)
- Created new URL (`/bible`) for viewing the entire Bible from the top and removed URL for viewing a specific chapter (`bible/urls.py`)
- Updated `bible/index.html` to display entire Bible
- Created Bible navigation menu / table of contents in `templates/partials/nav_bar.html`
- Wrote JS scripts in `templates/partials/nav_bar.html` and `bible/index.html` to create the following user flow: when the user clicks on a verse in the navbar or in the reading view, the page scrolls to that verse on the left, in addition to displaying the corresponding commentary on the right.

**Demo Videos:**

https://user-images.githubusercontent.com/67844715/229877886-01a9cac2-47b8-4090-9f73-ec411d2ed147.mp4

https://user-images.githubusercontent.com/67844715/229877938-5ab77f08-fd0b-46c1-86cb-461ecd176689.mp4

https://user-images.githubusercontent.com/67844715/229877953-e959830c-19a2-4326-80ba-86f118673654.mp4

**Next steps:**
- Reorganize Django templates and possibly create static files for custom CSS and JS scripts
- When jumping to another verse, the scrolling is unsmooth. This is because it is loading a new URL. The behavior for opening a new URL is to start at the top of the page, and to counteract this, an automatic scroll to the verse was added. A possible fix is to render the commentary on the right dynamically using AJAX. This would possibly eliminate the need to re-render and re-scroll the Bible on the left.
- Add scroll for menu.