### PR TITLE
Implemented voting for posts

### DIFF
--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -85,7 +85,7 @@
             </div>
 
             <div class="row">
-                <div class="col">
+                <div class="col-sm-2">
                     <form action="{% url "bible:toggle_vote" post_id=post.id %}">
                         {% csrf_token %}
                         <button type="submit" class="btn btn-outline-secondary btn-sm" value="Vote post">Vote ({{ post.vote_set.count }})</button>
@@ -93,14 +93,14 @@
                 </div>
 
                 {% if user.is_authenticated and post.author.user.pk == user.pk %} <!-- Only let users edit and delete their own comments   -->
-                    <div class="col">
+                    <div class="col text-end"">
                         <form action="{% url 'commentary:edit-post' post.pk %}" method="GET">
                             {% csrf_token %}
                             <button type="submit" class="btn btn-outline-secondary btn-sm" value="Edit post">Edit</button>
                         </form>
                     </div>
     
-                    <div class="col text-end">
+                    <div class="col-sm-2 text-end">
                         <form action="{% url 'commentary:delete-post' post.pk %}" method="GET">
                             {% csrf_token %}
                             <button type="submit" class="btn btn-danger btn-sm" value="Delete post">Delete</button>

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -69,7 +69,16 @@
         
             {% for post in posts %}
 
-            <h6>{{ post.title }}</h6>
+            <div class="row">
+                <div class="col-sm-2">
+                    <button>Upvote</button>
+                </div>
+
+                <div class="col text-start">
+                    <h6>{{ post.title }}</h6>
+                </div>
+            </div>
+            
             <p>{{ post.text }}</p>
             <a href="{% url "bible:index" book_symbol=book.symbol chapter_num=chapter.number verse_num=verse.number post_id=post.id %}">See more</a>
 

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -69,17 +69,7 @@
         
             {% for post in posts %}
 
-            <div class="row">
-                <div class="col">
-                    <h6>{{ post.title }}</h6>
-                </div>
-
-                <div class="col text-end">
-                    <div class="row">
-                        <h6><a href="{% url "bible:toggle_vote" post_id=post.id %}">Vote</a></h6>
-                    </div>
-                </div>
-            </div>
+            <h6>{{ post.title }}</h6>
             
             <p>{{ post.text }}</p>
             <a href="{% url "bible:index" book_symbol=book.symbol chapter_num=chapter.number verse_num=verse.number post_id=post.id %}">See more</a>

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -71,7 +71,7 @@
 
             <div class="row">
                 <div class="col-sm-2">
-                    <button>Upvote</button>
+                    <a href="{% url "bible:toggle_vote" post_id=post.id %}">Vote</a>
                 </div>
 
                 <div class="col text-start">

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -70,12 +70,14 @@
             {% for post in posts %}
 
             <div class="row">
-                <div class="col-sm-2">
-                    <a href="{% url "bible:toggle_vote" post_id=post.id %}">Vote</a>
+                <div class="col">
+                    <h6>{{ post.title }}</h6>
                 </div>
 
-                <div class="col text-start">
-                    <h6>{{ post.title }}</h6>
+                <div class="col text-end">
+                    <div class="row">
+                        <h6><a href="{% url "bible:toggle_vote" post_id=post.id %}">Vote</a></h6>
+                    </div>
                 </div>
             </div>
             
@@ -92,23 +94,30 @@
                 </div>
             </div>
 
-            {% if user.is_authenticated and post.author.user.pk == user.pk %} <!-- Only let users edit and delete their own comments   -->
             <div class="row">
                 <div class="col">
-                    <form action="{% url 'commentary:edit-post' post.pk %}" method="GET">
+                    <form action="{% url "bible:toggle_vote" post_id=post.id %}">
                         {% csrf_token %}
-                        <button type="submit" class="btn btn-outline-secondary btn-sm" value="Edit post">Edit</button>
+                        <button type="submit" class="btn btn-outline-secondary btn-sm" value="Vote post">Vote ({{ post.vote_set.count }})</button>
                     </form>
                 </div>
 
-                <div class="col text-end">
-                    <form action="{% url 'commentary:delete-post' post.pk %}" method="GET">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-danger btn-sm" value="Delete post">Delete</button>
-                    </form>
-                </div>
+                {% if user.is_authenticated and post.author.user.pk == user.pk %} <!-- Only let users edit and delete their own comments   -->
+                    <div class="col">
+                        <form action="{% url 'commentary:edit-post' post.pk %}" method="GET">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-outline-secondary btn-sm" value="Edit post">Edit</button>
+                        </form>
+                    </div>
+    
+                    <div class="col text-end">
+                        <form action="{% url 'commentary:delete-post' post.pk %}" method="GET">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-danger btn-sm" value="Delete post">Delete</button>
+                        </form>
+                    </div>
+                {% endif %}
             </div>
-            {% endif %}
 
             <hr/>
             {% endfor %}

--- a/bible/templates/bible/index.html
+++ b/bible/templates/bible/index.html
@@ -144,7 +144,7 @@
 </div>
 <script>
     // Scroll to selected verse (to counteract reloading the page to the top)
-    document.getElementById('verse-' + '{{ verse.get_id }}').scrollIntoView({behavior: 'smooth'});
+    document.getElementById('verse-' + '{{ verse.get_id }}').scrollIntoView({behavior: 'auto'});
 
     // Stop filter dropdown from closing when clicking inside
     document.getElementById('post-filter').addEventListener('click', function(e) {

--- a/bible/urls.py
+++ b/bible/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     # e.g. /bible/gen/1/ or /bible/gen/1/1/
     path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/', views.BibleCommentaryView.as_view(), name='index'),
     path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/<int:post_id>', views.BibleCommentaryView.as_view(), name='index'),
-    path('<int:post_id>', views.BibleCommentaryView.as_view(), name='index')
+    path('toggle_vote/<int:post_id>/', views.toggle_vote, name='toggle_vote')
 ]

--- a/bible/urls.py
+++ b/bible/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('', views.BibleCommentaryView.as_view(), name='index'),
     # e.g. /bible/gen/1/ or /bible/gen/1/1/
     path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/', views.BibleCommentaryView.as_view(), name='index'),
-    path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/<int:post_id>', views.BibleCommentaryView.as_view(), name='index')
+    path('<slug:book_symbol>/<int:chapter_num>/<int:verse_num>/<int:post_id>', views.BibleCommentaryView.as_view(), name='index'),
+    path('<int:post_id>', views.BibleCommentaryView.as_view(), name='index')
 ]

--- a/bible/views.py
+++ b/bible/views.py
@@ -94,20 +94,22 @@ class BibleCommentaryView(View):
             # TODO: Flash failure message and redirect to the same page
             else:
                 return HttpResponse('your post was not valid so it was not posted.')
-            
-    def toggle_vote(request, post_id):
-        if not request.user.is_authenticated:
-            return HttpResponse('You must be signed in to upvote posts.')
+  
+def toggle_vote(request, post_id):
+    # if not request.user.is_authenticated:
+    #     return HttpResponse('You must be signed in to upvote posts.')
+    
+    # profile = request.user.profile
+    
+    # post = get_object_or_404(Post, pk=post_id)
+    # votes = post.vote_set
+    
+    # if profile in votes.profiles:
+    #     vote = votes.profiles.get(profile=profile)
+    #     vote.delete()
         
-        profile = request.user.profile
-        
-        post = get_object_or_404(Post, pk=post_id)
-        votes = post.vote_set
-        
-        if profile in votes.profiles:
-            vote = votes.profiles.get(profile=profile)
-            vote.delete()
-            
-        else:
-            vote = Vote(voter=profile, post=post)
-            vote.save()
+    # else:
+    #     vote = Vote(voter=profile, post=post)
+    #     vote.save()
+
+    return HttpResponse('Successfully upvoted!')

--- a/bible/views.py
+++ b/bible/views.py
@@ -94,22 +94,23 @@ class BibleCommentaryView(View):
             # TODO: Flash failure message and redirect to the same page
             else:
                 return HttpResponse('your post was not valid so it was not posted.')
-  
-def toggle_vote(request, post_id):
-    # if not request.user.is_authenticated:
-    #     return HttpResponse('You must be signed in to upvote posts.')
-    
-    # profile = request.user.profile
-    
-    # post = get_object_or_404(Post, pk=post_id)
-    # votes = post.vote_set
-    
-    # if profile in votes.profiles:
-    #     vote = votes.profiles.get(profile=profile)
-    #     vote.delete()
-        
-    # else:
-    #     vote = Vote(voter=profile, post=post)
-    #     vote.save()
 
-    return HttpResponse('Successfully upvoted!')
+def toggle_vote(request, post_id):
+    if not request.user.is_authenticated:
+        return HttpResponse('You must be signed in to upvote posts.')
+    
+    profile = request.user.profile
+    
+    post = get_object_or_404(Post, pk=post_id)
+    votes = post.vote_set
+    vote = votes.filter(voter=profile).first()
+        
+    if vote != None:
+        # vote = votes.profiles.get(profile=profile)
+        vote.delete()
+        return HttpResponse("Removed upvote :(")
+        
+    else:
+        vote = Vote(voter=profile, post=post)
+        vote.save()
+        return HttpResponse('Added upvote :)')

--- a/bible/views.py
+++ b/bible/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 
 from .models import Book, Chapter, Verse
 from commentary.forms import PostCreationForm
-from commentary.models import Post
+from commentary.models import Post, Vote
 from commentary.filters import PostFilter
 
 from django.views import View
@@ -94,3 +94,20 @@ class BibleCommentaryView(View):
             # TODO: Flash failure message and redirect to the same page
             else:
                 return HttpResponse('your post was not valid so it was not posted.')
+            
+    def toggle_vote(request, post_pk):
+        if not request.user.is_authenticated:
+            return HttpResponse('You must be signed in to upvote posts.')
+        
+        profile = request.user.profile
+        
+        post = get_object_or_404(Post, pk=post_pk)
+        votes = post.vote_set
+        
+        if profile in votes.profiles:
+            vote = votes.profiles.get(profile=profile)
+            vote.delete()
+            
+        else:
+            vote = Vote(voter=profile, post=post)
+            vote.save()

--- a/bible/views.py
+++ b/bible/views.py
@@ -31,7 +31,7 @@ class BibleCommentaryView(View):
         verses = chapter.verse_set.order_by("id")
         verse = get_object_or_404(Verse, chapter=chapter, number=verse_num)
         
-        if not post_id:
+        if not post_id: # the user is viewing all the posts for a specific verse
             post_filter = PostFilter(request.GET, queryset=verse.post_set)
             postCreationForm = PostCreationForm()
             

--- a/bible/views.py
+++ b/bible/views.py
@@ -97,7 +97,7 @@ class BibleCommentaryView(View):
 
 def toggle_vote(request, post_id):
     if not request.user.is_authenticated:
-        return HttpResponse('You must be signed in to upvote posts.')
+        return HttpResponse('You must be signed in to upvote posts.') # TODO: give a more helpful response (flash a message?)
     
     profile = request.user.profile
     
@@ -108,9 +108,8 @@ def toggle_vote(request, post_id):
     if vote != None:
         # vote = votes.profiles.get(profile=profile)
         vote.delete()
-        return HttpResponse("Removed upvote :(")
-        
+        return HttpResponseRedirect(request.META['HTTP_REFERER']) # reload the page
     else:
         vote = Vote(voter=profile, post=post)
         vote.save()
-        return HttpResponse('Added upvote :)')
+        return HttpResponseRedirect(request.META['HTTP_REFERER']) # reload the page

--- a/bible/views.py
+++ b/bible/views.py
@@ -95,13 +95,13 @@ class BibleCommentaryView(View):
             else:
                 return HttpResponse('your post was not valid so it was not posted.')
             
-    def toggle_vote(request, post_pk):
+    def toggle_vote(request, post_id):
         if not request.user.is_authenticated:
             return HttpResponse('You must be signed in to upvote posts.')
         
         profile = request.user.profile
         
-        post = get_object_or_404(Post, pk=post_pk)
+        post = get_object_or_404(Post, pk=post_id)
         votes = post.vote_set
         
         if profile in votes.profiles:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django==4.1.7
+psycopg2==2.9.5
+django-filter==23.1
+django-crispy-forms==2.0
+crispy-bootstrap5==0.7

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,12 @@
+{% load static %}
+
 <!DOCTYPE html>
-<html>
+<html style="scroll-behavior: auto;">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" type="text/css" href="{% static 'base.css' %}">
 
     <!-- Bootstrap CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">

--- a/templates/partials/nav_bar.html
+++ b/templates/partials/nav_bar.html
@@ -49,7 +49,7 @@
                     {% for verse in chapter.verse_set.all %}
                         document.getElementById("nav-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").addEventListener('click', function(e) {
                             e.preventDefault();
-                            document.getElementById("verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").scrollIntoView({behavior: 'smooth'});
+                            document.getElementById("verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").scrollIntoView({behavior: 'auto'});
                             document.getElementById("verse-{{book.symbol}}-{{chapter.number}}-{{verse.number}}").click();
                         });
                     {% endfor %}

--- a/theologos/settings.py
+++ b/theologos/settings.py
@@ -135,6 +135,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static'),
+)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field


### PR DESCRIPTION
**Linked Issues:** Resolves #41

**Changes**:
* Added a `toggle_vote` function that takes in a post and either adds or removes a vote for that post, based on if the authenticated user had already voted for the post or not. 
* Added a 'Vote' button to the bible-commentary view to allow users to vote for posts via the UI

**Work to be done** (Issue: #76):
The UX for voting is not perfect. The user has no feedback for if they already voted for a post or not. A future change that can fix this is:
1. Detect if a post already has the authenticated user's vote or not
2. Conditionally color the 'Vote' button green/gray for a particular post based on the information in (1)

**Note**: A design decision to remove the scrolling animation to the selected verse was made. Upon clicking a verse, navigating to a verse via the nav bar, or voting on a post, the scroll animation occurs every time. This is "too much scrolling" and a snapping animation is preferred at the moment.

Below is a video displaying the vote functionality. It also displays the lack of UI feedback after the user has voted on a post.


https://user-images.githubusercontent.com/39920503/232934782-f3df3aea-63e4-431e-9158-b16419e5098b.mov