### PR TITLE
Fixed vote bug missing HttpResponseRedirect import

### DIFF
--- a/bible/views.py
+++ b/bible/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404, render, redirect
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 
 from .models import Book, Verse
 from commentary.forms import PostCreationForm


### PR DESCRIPTION
Previously, there was a NameError when the user tries to vote on a post even when logged in. The issue was that HttpResponseRedirect was not defined. Fixed by adding the import. Merge ASAP.