### PR TITLE
Fixed major account-related bugs

### DIFF
--- a/accounts/templates/accounts/register.html
+++ b/accounts/templates/accounts/register.html
@@ -15,7 +15,7 @@
             {{ userCreationForm|crispy }}
             {{ profileForm|crispy }}
 
-            <button type="submit" class="btn btn-primary">Register</button>
+            <button type="submit" class="btn btn-success mt-3">Register</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/user_confirm_delete.html
+++ b/accounts/templates/accounts/user_confirm_delete.html
@@ -8,7 +8,7 @@
 <div class="container">
     <div class="row mt-5">
         <div class="col-md-3 col-sm-6">
-            <a href="{% url 'accounts:detail' object.pk %}" class="btn btn-light">
+            <a href="{% url 'accounts:detail' %}" class="btn btn-light">
               Back to your account
             </a>
         </div>

--- a/accounts/templates/accounts/user_detail.html
+++ b/accounts/templates/accounts/user_detail.html
@@ -47,7 +47,7 @@
     
     <div class="row">
         <div class="col">
-            <form action="{% url 'accounts:delete' object.pk %}" method="GET">
+            <form action="{% url 'accounts:delete' %}" method="GET">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-danger" value="Delete account">Delete Account</button>
             </form>

--- a/accounts/templates/accounts/user_detail.html
+++ b/accounts/templates/accounts/user_detail.html
@@ -38,7 +38,7 @@
 
     <div class="row">
         <div class="col">
-            <form action="{% url 'accounts:edit' object.pk %}" method="GET">
+            <form action="{% url 'accounts:edit' %}" method="GET">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-outline-secondary" value="Edit account">Edit Account Information</button>
             </form>

--- a/accounts/templates/accounts/user_detail.html
+++ b/accounts/templates/accounts/user_detail.html
@@ -38,7 +38,7 @@
 
     <div class="row">
         <div class="col">
-            <form action="{% url 'accounts:edit' %}" method="GET">
+            <form action="{% url 'accounts:edit' %}" method="GET" style="padding-top:20px;">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-outline-secondary" value="Edit account">Edit Account Information</button>
             </form>
@@ -47,7 +47,7 @@
     
     <div class="row">
         <div class="col">
-            <form action="{% url 'accounts:delete' %}" method="GET">
+            <form action="{% url 'accounts:delete' %}" method="GET" style="padding-top:10px;">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-danger" value="Delete account">Delete Account</button>
             </form>

--- a/accounts/templates/accounts/user_update_form.html
+++ b/accounts/templates/accounts/user_update_form.html
@@ -10,7 +10,7 @@
     
   <div class="row mt-5">
       <div class="col-md-3 col-sm-6">
-          <a href="{% url 'accounts:detail' object.pk %}" class="btn btn-light">
+          <a href="{% url 'accounts:detail' %}" class="btn btn-light">
             Back to your account
           </a>
       </div>

--- a/accounts/templates/accounts/user_update_form.html
+++ b/accounts/templates/accounts/user_update_form.html
@@ -27,7 +27,7 @@
               {{ form | crispy }}
               {{ profileForm | crispy }}
               <div class="d-grid gap-2">
-                  <button class="btn btn-success mt-3">Save</button>
+                  <button type="submit" class="btn btn-success mt-3">Save changes</button>
               </div>
           </form>
       </div>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,6 @@ app_name = 'accounts'
 urlpatterns = [
     path('register/', register, name='register'), # /accounts/register/
     path('detail/', UserDetailView.as_view(), name='detail'), # /accounts/detail/
-    path('<int:pk>/edit/', UserUpdateView.as_view(), name='edit'), # /accounts/1/edit/
+    path('edit/', UserUpdateView.as_view(), name='edit'), # /accounts/edit/
     path('delete/', UserDeleteView.as_view(), name='delete') # /accounts/delete/
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -4,7 +4,7 @@ from .views import register, UserDetailView, UserUpdateView, UserDeleteView
 app_name = 'accounts'
 urlpatterns = [
     path('register/', register, name='register'), # /accounts/register/
-    path('<int:pk>/detail/', UserDetailView.as_view(), name='detail'), # /accounts/1/detail/
+    path('detail/', UserDetailView.as_view(), name='detail'), # /accounts/detail/
     path('<int:pk>/edit/', UserUpdateView.as_view(), name='edit'), # /accounts/1/edit/
     path('<int:pk>/delete/', UserDeleteView.as_view(), name='delete') # /accounts/1/delete/
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     path('register/', register, name='register'), # /accounts/register/
     path('detail/', UserDetailView.as_view(), name='detail'), # /accounts/detail/
     path('<int:pk>/edit/', UserUpdateView.as_view(), name='edit'), # /accounts/1/edit/
-    path('<int:pk>/delete/', UserDeleteView.as_view(), name='delete') # /accounts/1/delete/
+    path('delete/', UserDeleteView.as_view(), name='delete') # /accounts/delete/
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -16,7 +16,8 @@ from .models import User
 class UserDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["profile"] = self.get_object()
+        context["profile"] = self.get_object().profile
+        
         return context
     
     def get_object(self):
@@ -39,23 +40,33 @@ class UserUpdateView(UpdateView):
         return get_object_or_404(User, id=self.request.user.id)
     
     def form_valid(self, form):
-        user = self.get_object()
-        profileUpdateForm = ProfileForm(self.request.POST, instance=user.profile)
+        instance = self.get_object().profile
+        profileUpdateForm = ProfileForm(self.request.POST, instance=instance)
         
-        # need to check profile form separately
-        if profileUpdateForm.is_valid():
-            profileUpdateForm.save()
+        userFormValid = form.is_valid()
+        profileFormValid = profileUpdateForm.is_valid()
+        
+        if userFormValid and profileFormValid:
+            updatedUser = form.save()
+            updatedProfile = profileUpdateForm.save(commit=False)
+                        
+            updatedProfile.user = updatedUser
+            updatedProfile.save()
+            
             messages.success(self.request, 'Account updated successfully')
-            context = { 'object' : user, 'profile' : user.profile }
-            return render(self.request, 'accounts/user_detail.html', context)
+            return redirect("accounts:detail")
+        
         else:
             for error in profileUpdateForm.errors:
                 messages.error(self.request, profileUpdateForm.errors[error])
-                return redirect(self.request.path)
-            return HttpResponse('Failed to update account :(')
-    
+                
+            for error in form.errors:
+                messages.error(self.request, form.errors[error])
+                
+            return redirect(self.request.path)
+        
     def get_success_url(self):
-        return reverse_lazy("accounts:detail", kwargs={"pk":self.get_object().pk})
+        return reverse_lazy("accounts:detail")
 
 
 class UserDeleteView(DeleteView):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,6 @@
-from django.shortcuts import render, redirect
+from typing import Any, Optional
+from django.db import models
+from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpResponse
 from django.contrib import messages
 from django.contrib.auth.forms import UserCreationForm
@@ -6,22 +8,24 @@ from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView, DeleteView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
+# from django.contrib.auth.decorators import user_passes_test
 
 from profiles.forms import ProfileForm
 from .forms import UserCreationForm
 from .models import User
 
-class UserDetailView(DetailView, LoginRequiredMixin, UserPassesTestMixin):
+# @user_passes_test
+class UserDetailView(DetailView):
     model = User
         
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["profile"] = self.get_object().profile
+        context["profile"] = self.get_object()
         return context
     
-    def test_func(self):
-        user = self.get_object()
-        return self.request.user.pk == user.pk
+    def get_object(self):
+        # TODO: Add a helpful message instead of just 404'ing
+        return get_object_or_404(User, id=self.request.user.id)
     
 class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
     model = User

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -16,8 +16,6 @@ from .models import User
 
 # @user_passes_test
 class UserDetailView(DetailView):
-    model = User
-        
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["profile"] = self.get_object()
@@ -64,7 +62,6 @@ class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
 
 
 class UserDeleteView(DeleteView):
-    model = User
     success_url = reverse_lazy("login")
 
     def get_object(self):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -63,13 +63,13 @@ class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
         return self.request.user.pk == user.pk
 
 
-class UserDeleteView(DeleteView, LoginRequiredMixin, UserPassesTestMixin):
+class UserDeleteView(DeleteView):
     model = User
     success_url = reverse_lazy("login")
 
-    def test_func(self):
-        user = self.get_object()
-        return self.request.user.pk == user.pk
+    def get_object(self):
+        # TODO: Add a helpful message instead of just 404'ing
+        return get_object_or_404(User, id=self.request.user.id)
 
 
 def register(request):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,9 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.forms import UserCreationForm
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView, DeleteView
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
-# from django.contrib.auth.decorators import user_passes_test
 
 from profiles.forms import ProfileForm
 from .forms import UserCreationForm
@@ -25,8 +23,7 @@ class UserDetailView(DetailView):
         # TODO: Add a helpful message instead of just 404'ing
         return get_object_or_404(User, id=self.request.user.id)
     
-class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
-    model = User
+class UserUpdateView(UpdateView):
     fields = ["username", "first_name", "last_name", "email"]
     template_name_suffix = "_update_form"
         
@@ -36,6 +33,10 @@ class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
         context["profile"] = user.profile
         context["profileForm"] = ProfileForm(instance=user.profile)
         return context
+    
+    def get_object(self):
+        # TODO: Add a helpful message instead of just 404'ing
+        return get_object_or_404(User, id=self.request.user.id)
     
     def form_valid(self, form):
         user = self.get_object()
@@ -55,10 +56,6 @@ class UserUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
     
     def get_success_url(self):
         return reverse_lazy("accounts:detail", kwargs={"pk":self.get_object().pk})
-    
-    def test_func(self):
-        user = self.get_object()
-        return self.request.user.pk == user.pk
 
 
 class UserDeleteView(DeleteView):

--- a/templates/partials/nav_bar.html
+++ b/templates/partials/nav_bar.html
@@ -70,7 +70,7 @@
                 <a class="nav-link dropdown-toggle navbar-last" href="#" data-bs-toggle="dropdown">Hello, {{ request.user.username }}</a>
 
                 <div class="dropdown-menu">
-                    <a class="dropdown-item" href={% url 'accounts:detail' request.user.id %}>Account</a>
+                    <a class="dropdown-item" href={% url 'accounts:detail' %}>Account</a>
                     <a class="dropdown-item" href={% url 'logout' %}>Log out</a>
                 </div>
             </div>

--- a/templates/partials/nav_bar.html
+++ b/templates/partials/nav_bar.html
@@ -65,12 +65,12 @@
         {% endif %}
 
         <div class="navbar-nav">
-            {% if user.is_authenticated %}
+            {% if request.user.is_authenticated %}
             <div class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle navbar-last" href="#" data-bs-toggle="dropdown">Hello, {{ user.username }}</a>
+                <a class="nav-link dropdown-toggle navbar-last" href="#" data-bs-toggle="dropdown">Hello, {{ request.user.username }}</a>
 
                 <div class="dropdown-menu">
-                    <a class="dropdown-item" href={% url 'accounts:detail' user.pk %}>Account</a>
+                    <a class="dropdown-item" href={% url 'accounts:detail' request.user.id %}>Account</a>
                     <a class="dropdown-item" href={% url 'logout' %}>Log out</a>
                 </div>
             </div>


### PR DESCRIPTION
**Linked Issues**: Resolves #77 

**Brief Description**: Before this PR, anyone could manipulate the URL to view, modify, and delete other users' accounts. This PR fixes said problems.

* Primary changes are in `accounts/views.py`. Changed the read, edit, and delete views to not query all users' accounts. Instead, it now just uses the signed in user's ID (`request.user.id`) to find the right account.
* The corresponding URLs to the read, edit, and delete views were updated to not include an `<int:pk>` anymore. As mentioned, only the signed in user's ID is used to find the right account now.
* Fixed a bug where not all account detail changes were saved when updating an account.